### PR TITLE
Fix canvas canvas height on mobile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,12 @@ if (!canvas) {
 }
 const resolution = window.screen.availWidth / window.screen.availHeight;
 canvas.width = 1000;
-canvas.height = canvas.width / resolution;
+
+if (resolution < 1) {
+    canvas.height = canvas.width / 1.6;
+} else {
+    canvas.height = canvas.width / resolution;
+}
 
 const context = canvas.getContext('2d');
 if (!context) {

--- a/src/style.css
+++ b/src/style.css
@@ -37,7 +37,7 @@ html, body {
 }
 
 #score-board {
-    width: 100%;
+    width: 100vw;
 }
 
 @media (min-width: 1250px) {


### PR DESCRIPTION
- The last PR created a bug where, on mobile devices in portrait orientation, the canvas height was too large for the screen.